### PR TITLE
Primordial support for a Minecraft like teleporting system and other small fixes

### DIFF
--- a/scripts/myMod.lua
+++ b/scripts/myMod.lua
@@ -13,8 +13,8 @@ Methods.TeleportToPlayer = function(pid, originPlayer, targetPlayer)
 	if originPlayer ~= nil and targetPlayer ~= nil and type(tonumber(originPlayer)) == "number" and type(tonumber(targetPlayer)) == "number" then
 		if tonumber(originPlayer) >= 0 and tonumber(originPlayer) <= #Players and tonumber(targetPlayer) >= 0 and tonumber(targetPlayer) <= #Players then
 			if Players[tonumber(originPlayer)]:IsLoggedOn() and Players[tonumber(targetPlayer)]:IsLoggedOn() then
-				local originPlayerName = Players[originPlayer].name
-				local targetPlayerName = Players[targetPlayer].name
+				local originPlayerName = Players[tonumber(originPlayer)].name
+				local targetPlayerName = Players[tonumber(targetPlayer)].name
 				local targetCell
 				if tes3mp.IsInInterior(targetPlayer) then
 					targetCell = tes3mp.GetCell(targetPlayer)

--- a/scripts/myMod.lua
+++ b/scripts/myMod.lua
@@ -5,12 +5,49 @@ function string:split(sep)
         self:gsub(pattern, function(c) fields[#fields+1] = c end)
         return fields
 end
-
 local Methods = {}
 
 local Players
 
-Methods.GetPlayerList = function()
+Methods.TeleportToPlayer = function(pid, originPlayer, targetPlayer)
+	if originPlayer ~= nil and targetPlayer ~= nil and type(tonumber(originPlayer)) == "number" and type(tonumber(targetPlayer)) == "number" then
+		if tonumber(originPlayer) >= 0 and tonumber(originPlayer) <= #Players and tonumber(targetPlayer) >= 0 and tonumber(targetPlayer) <= #Players then
+			if Players[tonumber(originPlayer)]:IsLoggedOn() and Players[tonumber(targetPlayer)]:IsLoggedOn() then
+				local originPlayerName = tes3mp.GetName(originPlayer)
+				local targetPlayerName = tes3mp.GetName(targetPlayer)
+				local targetCell
+				if tes3mp.IsInInterior(targetPlayer) then
+					targetCell = tes3mp.GetCell(targetPlayer)
+				else
+					targetCell = tes3mp.GetCell(targetPlayer) -- Placeholder
+				end
+				if targetCell == nil then
+					targetCell = "ToddTest"
+				end
+				local originMessage = "You have been teleported to " .. targetPlayerName .. "'s location. (" .. targetCell .. ")\n"
+				local targetMessage = "Teleporting ".. originPlayerName .." to your location.\n"
+				tes3mp.SendMessage(originPlayer, originMessage, 0)
+				tes3mp.SendMessage(targetPlayer, targetMessage, 0)
+				tes3mp.SetCell(originPlayer,targetCell)
+			else
+				local message = "That player is not logged on!\n"
+				tes3mp.SendMessage(pid, message, 0)
+			end
+		else
+			local message = "That player is not logged on!\n"
+			tes3mp.SendMessage(pid, message, 0)
+		end
+	else
+		local message = "Please specify the player ID.\n"
+		tes3mp.SendMessage(pid, message, 0)
+	end
+end
+
+Methods.GetConnectedPlayerNumber = function()
+	return #Players+1
+end
+
+Methods.GetConnectedPlayerList = function()
 	local list = ""
 	local divider = ""
 	for i=0,#Players do

--- a/scripts/myMod.lua
+++ b/scripts/myMod.lua
@@ -13,8 +13,8 @@ Methods.TeleportToPlayer = function(pid, originPlayer, targetPlayer)
 	if originPlayer ~= nil and targetPlayer ~= nil and type(tonumber(originPlayer)) == "number" and type(tonumber(targetPlayer)) == "number" then
 		if tonumber(originPlayer) >= 0 and tonumber(originPlayer) <= #Players and tonumber(targetPlayer) >= 0 and tonumber(targetPlayer) <= #Players then
 			if Players[tonumber(originPlayer)]:IsLoggedOn() and Players[tonumber(targetPlayer)]:IsLoggedOn() then
-				local originPlayerName = tes3mp.GetName(originPlayer)
-				local targetPlayerName = tes3mp.GetName(targetPlayer)
+				local originPlayerName = Players[originPlayer].name
+				local targetPlayerName = Players[targetPlayer].name
 				local targetCell
 				if tes3mp.IsInInterior(targetPlayer) then
 					targetCell = tes3mp.GetCell(targetPlayer)
@@ -44,7 +44,13 @@ Methods.TeleportToPlayer = function(pid, originPlayer, targetPlayer)
 end
 
 Methods.GetConnectedPlayerNumber = function()
-	return #Players+1
+	local playernumber = 0
+	for i=0,#Players do
+		if Players[i]:IsLoggedOn() then
+			playernumber = playernumber + 1
+		end
+	end
+	return playernumber
 end
 
 Methods.GetConnectedPlayerList = function()
@@ -56,7 +62,9 @@ Methods.GetConnectedPlayerList = function()
 		else
 			divider = ", "
 		end
-		list = list .. tostring(Players[i].name) .. " (" .. tostring(Players[i].pid) .. ")" .. divider
+		if Players[i]:IsLoggedOn() then
+			list = list .. tostring(Players[i].name) .. " (" .. tostring(Players[i].pid) .. ")" .. divider
+		end
 	end
 	return list
 end
@@ -83,7 +91,7 @@ end
 
 Methods.OnPlayerDisconnect = function(pid)
 	Players[pid]:Destroy()
-    Players[pid] = nil
+	Players[pid] = nil
 end
 
 Methods.OnPlayerMessage = function(pid, message)

--- a/scripts/myMod.lua
+++ b/scripts/myMod.lua
@@ -93,31 +93,31 @@ Methods.OnPlayerMessage = function(pid, message)
 	
 	if cmd[1] == "register" or cmd[1] == "reg" then
 		if Players[pid]:IsLoggedOn() then
-			Players[pid]:Message("You are already logged in.")
+			Players[pid]:Message("You are already logged in.\n")
 			return 0
 		elseif Players[pid]:HasAccount() then
-			Players[pid]:Message("You already have an account. Try \"/login password\".")
+			Players[pid]:Message("You already have an account. Try \"/login password\".\n")
 			return 0
 		elseif cmd[2] == nil then
-			Players[pid]:Message("Incorrect password!")
+			Players[pid]:Message("Incorrect password!\n")
 			return 0 
 		end
 		Players[pid]:Registered(cmd[2])
 		return 0
 	elseif cmd[1] == "login" then
 		if Players[pid]:IsLoggedOn() then
-			Players[pid]:Message("You are already logged in.")
+			Players[pid]:Message("You are already logged in.\n")
 			return 0
 		elseif not Players[pid]:HasAccount() then
-			Players[pid]:Message("You do not have an account. Try \"/register password\".")
+			Players[pid]:Message("You do not have an account. Try \"/register password\".\n")
 			return 0
 		elseif cmd[2] == nil then
-			Players[pid]:Message("Password can not be empty")
+			Players[pid]:Message("Password can not be empty\n")
 			return 0 
 		end
 		Players[pid]:Load()
 		if Players[pid].data.general.password ~= cmd[2] then
-			Players[pid]:Message("Incorrect password!")
+			Players[pid]:Message("Incorrect password!\n")
             return 0
 		end
 		Players[pid]:LoggedOn()

--- a/scripts/myMod.lua
+++ b/scripts/myMod.lua
@@ -91,7 +91,7 @@ end
 
 Methods.OnPlayerDisconnect = function(pid)
 	Players[pid]:Destroy()
-	Players[pid] = nil
+--	Players[pid] = nil
 end
 
 Methods.OnPlayerMessage = function(pid, message)

--- a/scripts/player.lua
+++ b/scripts/player.lua
@@ -94,7 +94,7 @@ function Player:Destroy()
 		print("Saving player...")
 		self:Save()
 	end
-    self.loggedOn = false
+	self.loggedOn = false
 	self.hasAccount = nil
 end
 

--- a/scripts/server.lua
+++ b/scripts/server.lua
@@ -23,10 +23,12 @@ function OnLogin(pid) -- timer-based event see myMod.OnPlayerConnect
 end
 
 function OnPlayerDisconnect(pid)
+	print("Player with pid("..pid..") disconnected.")
+	myMod.OnPlayerDisconnect(pid)
 end
 
 function OnPlayerDeath(pid)
-    tes3mp.Resurrect(pid)
+	tes3mp.Resurrect(pid)
 end
 
 function OnPlayerResurrect(pid)

--- a/scripts/server.lua
+++ b/scripts/server.lua
@@ -35,7 +35,8 @@ end
 function OnPlayerChangeCell(pid)
 	local curCell = tes3mp.GetCell(pid);
 	if curCell ~= "ToddTest" or not tes3mp.IsInInterior(pid) then
-		tes3mp.SetCell(pid, "ToddTest") end
+		--tes3mp.SetCell(pid, "ToddTest")
+	end
 end
 
 function OnPlayerUpdateEquiped(pid)
@@ -58,15 +59,26 @@ function OnPlayerSendMessage(pid, message)
 			for i=0,26 do
 				tes3mp.SetSkill(pid, i, 666);
 			end
-			return 0
-		end
-		if cmd[1] == "list" then
-			local message = "Connected players: " .. myMod.GetPlayerList() .. "\n"
+		elseif cmd[1] == "list" then
+			local text
+			if myMod.GetConnectedPlayerNumber() == 1 then
+				text = "player"
+			else
+				text = "players"
+			end
+			local message = myMod.GetConnectedPlayerNumber() .. " connected " .. text .. ": " .. myMod.GetConnectedPlayerList() .. "\n"
 			tes3mp.SendMessage(pid, message, 0)
-			return 0
+		elseif cmd[1] == "teleport" or cmd[1] == "tp" then
+			myMod.TeleportToPlayer(pid, cmd[2], pid)
+		elseif cmd[1] == "teleportto" or cmd[1] == "tpto" then
+			myMod.TeleportToPlayer(pid, pid, cmd[2])
+		else
+			local message = "Not a valid command. Type /help for more info.\n"
+			tes3mp.SendMessage(pid, message, 0)
 		end
+		return 0 -- commands should be hidden
 	end
-	return 1 -- default behavior
+	return 1 -- default behavior, chat messages should not
 end
 
 function OnPlayerEndCharGen(pid)

--- a/scripts/server.lua
+++ b/scripts/server.lua
@@ -19,15 +19,24 @@ function OnPlayerConnect(pid)
 end
 
 function OnLogin(pid) -- timer-based event see myMod.OnPlayerConnect
+	local pname = tes3mp.GetName(pid)
+	local message = pname.." ("..pid..") ".."joined the server.\n"
+	tes3mp.SendMessage(pid, message, 1)
 	myMod.AuthCheck(pid)
 end
 
 function OnPlayerDisconnect(pid)
 	print("Player with pid("..pid..") disconnected.")
+	local pname = tes3mp.GetName(pid)
+	local message = pname.." ("..pid..") ".."left the server.\n"
+	tes3mp.SendMessage(pid, message, 1)
 	myMod.OnPlayerDisconnect(pid)
 end
 
 function OnPlayerDeath(pid)
+	local pname = tes3mp.GetName(pid)
+	local message = pname.." ("..pid..") ".."died.\n"
+	tes3mp.SendMessage(pid, message, 1)
 	tes3mp.Resurrect(pid)
 end
 


### PR DESCRIPTION
These changes provide primordial support for a Minecraft like teleporting system, that allows the player to goto or bring other players to their location.

![2016-07-15-18 00 17-screenshot](https://cloud.githubusercontent.com/assets/1028205/16886970/34e352fc-4acf-11e6-91c9-8c7a3719c24a.jpg)

Currently it only works with cells, exteriors spaces shall come later on.

It would also be nice to, in addition to teleporting players into the target cells, have them change position according to the position of the target player. Unfortunately I could not get tes3mp.GetPos() to work on the Lua scripts, it segfaulted the server without any relevant information (@Koncord is working on it) .

These commits also bring changes to the player list command, now displaying the number of players connected, provide some fixes regarding the login message strings, makes server.lua call myMod.OnPlayerDisconnect() whenever a player quits and broadcasts informative messages on login, death and departure.

![2016-07-16-20 11 52-screenshot](https://cloud.githubusercontent.com/assets/1028205/16896732/97cd1b9a-4b93-11e6-8afa-fe3bbcb11746.jpg)

PS: This takes care of #2 
