### PR TITLE
Absolute location support for teleporter, rank based command permissions, new commands

### DIFF
--- a/scripts/player.lua
+++ b/scripts/player.lua
@@ -77,7 +77,7 @@ function Player.new(pid)
 		},
     };
 	self.accountName = tes3mp.GetName(pid)..".txt"
-    self.pid = pid
+	self.pid = pid
 	self.loggedOn = false
 	self.tid_login = nil
 	self.admin = 0
@@ -125,16 +125,16 @@ function Player:IsLoggedOn()
 end
 
 function Player:IsAdmin()
-	return self.admin == 2
+	return self.data.general.admin == 2
 end
 
 function Player:IsModerator()
-	return self.admin == 1
+	return self.data.general.admin == 1
 end
 
 function Player:PromoteModerator(other)
 	if self.IsAdmin() then
-		other.admin = 1
+		other.data.general.admin = 1
 		return true
 	end
 	return false


### PR DESCRIPTION
Made that part of the teleporter command that verifies if the user input corresponds to a valid id of a logged on player into an independent function, that can be used to verify user input on other commands.

The teleporter command utility now brings people not only to the desired cell but also to the coordinates of the target player.
It also works on the exterior, but only if the teleporting player is already on the exterior.
**We need a SetCell like function that brings people from interior cells to the exterior, like the command "coc Balmora" does.**

Implemented support for rank based command permissions. Fixes regarding rank verification functions.

Added a few new commands including /getpos, which will be useful to debug issues regarding to disappearing players, as they display crazy coordinates server side whenever they are invisible.
