### PR TITLE
Add chat key prompts

### DIFF
--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -169,6 +169,8 @@ eventHandler.OnGUIAction = function(pid, idGui, data)
                 else
                     Players[pid]:FinishLogin()
                     Players[pid]:Message("You have successfully logged in.\n")
+                    Players[pid]:Message("Use Y by default to chat or change it from your client config.\n" .. 
+                        "Use F2 by default to hide the chat window.\n")
                 end
             elseif idGui == guiHelper.ID.REGISTER then
                 if data == nil then
@@ -177,8 +179,9 @@ eventHandler.OnGUIAction = function(pid, idGui, data)
                     return true
                 end
                 Players[pid]:Register(data)
-                Players[pid]:Message("You have successfully registered.\nUse Y by default to chat or " ..
-                    "change it from your client config.\n")
+                Players[pid]:Message("You have successfully registered.\n")
+                Players[pid]:Message("Use Y by default to chat or change it from your client config.\n" .. 
+                    "Use F2 by default to hide the chat window.\n")
             end
         end
     end


### PR DESCRIPTION
Added info for the chat hide key, and also made the chat information appear to players logging in (previously it only showed upon registering a character, so players might forget).
I didn't combine the logging/registering messages with the info messages in the code because I thought it looked pwettier, there's no reason they can't all be part of the same string :P