### PR TITLE
Couple fixes

### DIFF
--- a/scripts/contentFixer.lua
+++ b/scripts/contentFixer.lua
@@ -11,7 +11,7 @@ refNumDeletionsByCell["-1, -9"] = { 268178, 297457, 297459, 297460, 299125 }
 refNumDeletionsByCell["-2, -9"] = { 172848, 172850, 172852, 289104, 297461, 397559 }
 refNumDeletionsByCell["-2, -10"] = { 297463, 297464, 297465, 297466 }
 
-local deadlyItems = { "keening" }
+local deadlyItems = { "keening", "sunder" }
 
 function contentFixer.FixCell(pid, cellDescription)
 

--- a/scripts/inventoryHelper.lua
+++ b/scripts/inventoryHelper.lua
@@ -103,12 +103,14 @@ function inventoryHelper.compareClosenessToItem(idealItem, comparedItem, otherIt
     end
 
     -- A difference in souls also instantly resolves the comparison
-    if idealItem.soul ~= nil and not comparedItem.soul:ciEqual(otherItem.soul) then
-        if idealItem.soul:ciEqual(comparedItem.soul) then
-            return true
-        elseif idealItem.soul:ciEqual(otherItem.soul) then
-            return false
-        end
+    if otherItem.soul ~= "" then
+		if idealItem.soul ~= nil and not comparedItem.soul:ciEqual(otherItem.soul) then
+			if idealItem.soul:ciEqual(comparedItem.soul) then
+				return true
+			elseif idealItem.soul:ciEqual(otherItem.soul) then
+				return false
+			end
+		end
     end
 
     -- The TES3MP server doesn't yet load up data files, so it doesn't actually know what the


### PR DESCRIPTION
Fix two problems I found.
- When you try to throw away gold from inventory, it will cause server crash, the problem was detected in case comparing in inventory helper, so simple solution is check if we have empty soul
- Second problem is: Sunder also can kill player on spawn, so add it to "Deadly items"