### PR TITLE
Making guiID's great again

### DIFF
--- a/scripts/guiHelper.lua
+++ b/scripts/guiHelper.lua
@@ -1,8 +1,8 @@
 tableHelper = require("tableHelper")
 
 guiHelper = {}
-
-guiHelper.ID = tableHelper.enum({"LOGIN", "REGISTER", "PLAYERSLIST", "CELLSLIST"})
+guiHelper.names = {"LOGIN", "REGISTER", "PLAYERSLIST", "CELLSLIST"}
+guiHelper.ID = tableHelper.enum(guiHelper.names)
 
 guiHelper.ShowLogin = function(pid)
     tes3mp.PasswordDialog(pid, guiHelper.ID.LOGIN, "Enter your password:", "")


### PR DESCRIPTION
By pulling apart the creation of the enum table that is used by guiHelper it allows for other scripters to insert into the table guiHelper.names at the end and enum it again.
This allows for people to use it more dynamically and without conflicting guiID's.
I'm terrible at naming things. So you might want another name for the table.