### PR TITLE
Fix for saving offline players

### DIFF
--- a/scripts/logicHandler.lua
+++ b/scripts/logicHandler.lua
@@ -76,6 +76,9 @@ end
 
 -- Get the "Name (pid)" representation of a player used in chat
 logicHandler.GetChatName = function(pid)
+    if pid == nil then
+        return "Unlogged player (nil)"
+    end
 
     if Players[pid] ~= nil then
         return Players[pid].name .. " (" .. pid .. ")"

--- a/scripts/player/json.lua
+++ b/scripts/player/json.lua
@@ -35,11 +35,7 @@ end
 
 function Player:Save()
     if self.hasAccount then
-		if self.pid == nil then
-			tes3mp.LogMessage(enumerations.log.INFO, "Saving player " .. self.accountName)
-		else
-			tes3mp.LogMessage(enumerations.log.INFO, "Saving player " .. logicHandler.GetChatName(self.pid))
-		end
+        tes3mp.LogMessage(enumerations.log.INFO, "Saving player " .. logicHandler.GetChatName(self.pid))
         jsonInterface.save("player/" .. self.accountFile, self.data, config.playerKeyOrder)
     end
 end

--- a/scripts/player/json.lua
+++ b/scripts/player/json.lua
@@ -35,7 +35,11 @@ end
 
 function Player:Save()
     if self.hasAccount then
-        tes3mp.LogMessage(enumerations.log.INFO, "Saving player " .. logicHandler.GetChatName(self.pid))
+		if self.pid == nil then
+			tes3mp.LogMessage(enumerations.log.INFO, "Saving player " .. self.accountName)
+		else
+			tes3mp.LogMessage(enumerations.log.INFO, "Saving player " .. logicHandler.GetChatName(self.pid))
+		end
         jsonInterface.save("player/" .. self.accountFile, self.data, config.playerKeyOrder)
     end
 end


### PR DESCRIPTION
If you load an offline player with "logicHandler.GetPlayerByName(playerName)" you get a player with no pid so "logicHandler.GetChatName(self.pid)" here would get a nil value.