### PR TITLE
Add configurable data path

### DIFF
--- a/lib/lua/jsonInterface.lua
+++ b/lib/lua/jsonInterface.lua
@@ -44,7 +44,7 @@ function jsonInterface.load(fileName)
         return nil
     end
 
-    local home = tes3mp.GetDataPath() .. "/"
+    local home = config.dataPath .. "/"
     local file = jsonInterface.ioLibrary.open(home .. fileName, 'r')
 
     if file ~= nil then
@@ -84,7 +84,7 @@ function jsonInterface.writeToFile(fileName, content)
         return false
     end
 
-    local home = tes3mp.GetDataPath() .. "/"
+    local home = config.dataPath .. "/"
     local file = jsonInterface.ioLibrary.open(home .. fileName, 'w+b')
 
     if file ~= nil then

--- a/scripts/cell/json.lua
+++ b/scripts/cell/json.lua
@@ -11,7 +11,7 @@ function Cell:__init(cellDescription)
     -- Ensure filename is valid
     self.entryName = fileHelper.fixFilename(cellDescription)
 
-    self.entryFile = tes3mp.GetCaseInsensitiveFilename(tes3mp.GetDataPath() .. "/cell/", self.entryName .. ".json")
+    self.entryFile = tes3mp.GetCaseInsensitiveFilename(config.dataPath .. "/cell/", self.entryName .. ".json")
 
     if self.entryFile == "invalid" then
         self.hasEntry = false

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -1,5 +1,8 @@
 config = {}
 
+-- The path used by the server for its data folder
+config.dataPath = tes3mp.GetDataPath()
+
 -- The game mode displayed for this server in the server browser
 config.gameMode = "Default"
 

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -304,7 +304,7 @@ config.databaseType = "json"
 
 -- The location of the database file
 -- Note: Not applicable when using json
-config.databasePath = tes3mp.GetDataPath() .. "/database.db" -- Path where database is stored
+config.databasePath = config.dataPath .. "/database.db" -- Path where database is stored
 
 -- Disallow players from including the following in their own names or the names of their custom items
 -- Note: Unfortunately, these are based on real names that trolls have been using on servers

--- a/scripts/player/json.lua
+++ b/scripts/player/json.lua
@@ -11,7 +11,7 @@ function Player:__init(pid, playerName)
     -- Ensure filename is valid
     self.accountName = fileHelper.fixFilename(playerName)
 
-    self.accountFile = tes3mp.GetCaseInsensitiveFilename(tes3mp.GetDataPath() .. "/player/", self.accountName .. ".json")
+    self.accountFile = tes3mp.GetCaseInsensitiveFilename(config.dataPath .. "/player/", self.accountName .. ".json")
 
     if self.accountFile == "invalid" then
         self.hasAccount = false

--- a/scripts/recordstore/json.lua
+++ b/scripts/recordstore/json.lua
@@ -12,7 +12,7 @@ function RecordStore:__init(storeType)
     self.recordstoreFile = storeType .. ".json"
 
     if self.hasEntry == nil then
-        local home = tes3mp.GetDataPath() .. "/recordstore/"
+        local home = config.dataPath .. "/recordstore/"
         local file = io.open(home .. self.recordstoreFile, "r")
         if file ~= nil then
             io.close()

--- a/scripts/stateHelper.lua
+++ b/scripts/stateHelper.lua
@@ -144,7 +144,7 @@ function StateHelper:LoadMap(pid, stateObject)
 
     for index, cellDescription in pairs(stateObject.data.mapExplored) do
 
-        local filePath = tes3mp.GetDataPath() .. "/map/" .. cellDescription .. ".png"
+        local filePath = config.dataPath .. "/map/" .. cellDescription .. ".png"
 
         if tes3mp.DoesFilePathExist(filePath) then
 

--- a/scripts/world/base.lua
+++ b/scripts/world/base.lua
@@ -322,7 +322,7 @@ function BaseWorld:SaveMapTiles(pid)
         local cellY = tes3mp.GetMapTileCellY(index)
         local filename = cellX .. ", " .. cellY .. ".png"
 
-        tes3mp.SaveMapTileImageFile(index, tes3mp.GetDataPath() .. "/map/" .. filename)
+        tes3mp.SaveMapTileImageFile(index, config.dataPath .. "/map/" .. filename)
     end
 end
 

--- a/scripts/world/json.lua
+++ b/scripts/world/json.lua
@@ -10,7 +10,7 @@ function World:__init()
     self.worldFile = "world.json"
 
     if self.hasEntry == nil then
-        local home = tes3mp.GetDataPath() .. "/world/"
+        local home = config.dataPath .. "/world/"
         local file = io.open(home .. self.worldFile, "r")
         if file ~= nil then
             io.close()


### PR DESCRIPTION
Allows the path for the server's data to be set using the config option `config.dataPath` inside `config.lua`. I did some brief testing on my Windows 10 setup and it seemed to work, though testing on other OSes might be a good idea (not sure if necessary but whatever).

There's a chance I missed something, especially if it's sql related, since I don't fully understand it :p