### PR TITLE
Add equipmentIndex key to player inventory table

### DIFF
--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -602,9 +602,9 @@ eventHandler.OnPlayerItemUse = function(pid)
         customEventHooks.triggerHandlers("OnPlayerItemUse", eventStatus, {pid, itemRefId})
     end
 
-    -- Unequip whatever was just used, if it's equipped. This is just in case its the case where a piece of
-    -- equipment is swapped in-place with another piece with the same refId but a different condition. The
-    -- piece of equipment will be set back to equipped at the next call to SaveEquipment
+    -- If the item matches a refId in the equipment table, unequip that equipment. This is the only
+    -- place we can detect when equipments with identical refIds but different conditions are swapped
+    -- in-place. The piece of equipment will be set back to equipped at the next call to SaveEquipment.
     for index = 0, tes3mp.GetEquipmentSize() - 1 do
         if Players[pid].data.equipment[index] ~= nil and Players[pid].data.equipment[index].refId == itemRefId then
             local eq = Players[pid].data.equipment[index]

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -601,6 +601,16 @@ eventHandler.OnPlayerItemUse = function(pid)
         end
         customEventHooks.triggerHandlers("OnPlayerItemUse", eventStatus, {pid, itemRefId})
     end
+
+    -- Add use time marker to a piece of equipment that matches this itemRefId. I don't like this
+    -- solution and I'm hopeful there is a better solution to swapping equipment in-place that doesn't
+    -- involve timestamps and such. I suspect it is as simple as "unequipping" the piece of equipment
+    -- that got swapped right here, but I haven't tested that yet so this will have to do for now.
+    for index = 0, tes3mp.GetEquipmentSize() - 1 do
+        if Players[pid].data.equipment[index] ~= nil and Players[pid].data.equipment[index].refId == itemRefId then
+            Players[pid].data.equipment[index].useTime = os.time()
+        end
+    end
 end
 
 eventHandler.OnPlayerMiscellaneous = function(pid)

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -602,13 +602,14 @@ eventHandler.OnPlayerItemUse = function(pid)
         customEventHooks.triggerHandlers("OnPlayerItemUse", eventStatus, {pid, itemRefId})
     end
 
-    -- Add use time marker to a piece of equipment that matches this itemRefId. I don't like this
-    -- solution and I'm hopeful there is a better solution to swapping equipment in-place that doesn't
-    -- involve timestamps and such. I suspect it is as simple as "unequipping" the piece of equipment
-    -- that got swapped right here, but I haven't tested that yet so this will have to do for now.
+    -- Unequip whatever was just used, if it's equipped. This is just in case its the case where a piece of
+    -- equipment is swapped in-place with another piece with the same refId but a different condition. The
+    -- piece of equipment will be set back to equipped at the next call to SaveEquipment
     for index = 0, tes3mp.GetEquipmentSize() - 1 do
         if Players[pid].data.equipment[index] ~= nil and Players[pid].data.equipment[index].refId == itemRefId then
-            Players[pid].data.equipment[index].useTime = os.time()
+            local eq = Players[pid].data.equipment[index]
+            inventoryHelper.setItemToUnequipped(Players[pid].data.inventory, itemRefId, eq.charge, eq.enchantmentCharge)
+            Players[pid].data.equipment[index] = nil
         end
     end
 end

--- a/scripts/inventoryHelper.lua
+++ b/scripts/inventoryHelper.lua
@@ -64,18 +64,6 @@ function inventoryHelper.getItemIndex(inventory, refId, charge, enchantmentCharg
     return nil
 end
 
--- Gets the index of the inventory item with refId that has an equipmentIndex value
-function inventoryHelper.getItemIndexOfEquipment(inventory, refId)
-
-    for itemIndex, item in pairs(inventory) do
-        if item.refId == refId and item.equipmentIndex ~= nil then
-            return itemIndex
-        end
-    end
-
-    return nil
-end
-
 -- Gets the index of the inventory item with the given equipmentIndex, or nil if no
 -- inventory item has the given equipmentIndex
 function inventoryHelper.getItemIndexByEquipmentIndex(inventory, equipmentIndex)
@@ -161,8 +149,17 @@ end
 
 function inventoryHelper.setItemToUnequipped(inventory, refId, charge, enchantmentCharge)
 
-    local index = inventoryHelper.getItemIndexOfEquipment(inventory, refId)
+    local index = nil
 
+    -- find the inventory index with an equipmentIndex and which matches the given refId
+    for itemIndex, item in pairs(inventory) do
+        if item.refId == refId and item.equipmentIndex ~= nil then
+            index = itemIndex
+            break
+        end
+    end
+
+    -- if we got an index, then that's the index of the inventory item to unequip
     if index ~= nil then
         -- save soul and count, we'll need them in a moment
         local itemSoul = inventory[index].soul

--- a/scripts/inventoryHelper.lua
+++ b/scripts/inventoryHelper.lua
@@ -31,12 +31,10 @@ end
 -- as that should be considered to be "equipment" for the purposes of altering an item's charges or condition
 function inventoryHelper.getItemIndex(inventory, refId, charge, enchantmentCharge, soul, equipmentIndex)
 
-    -- short circuit: if equipmentIndex is not nil, then all we need to do is search for the itemIndex
-    -- whose equipmentIndex matches. If this is false, then move on and make sure not to return an item
-    -- whose equipmentIndex is non-nil later on in the function.
+    -- short circuit: if equipmentIndex is not nil, then just search for the itemIndex whose equipmentIndex matches.
+    -- If equipmentIndex is nil, then continue, and do not return any entries that have an equipmentIndex.
     if equipmentIndex ~= nil then return getItemIndexByEquipmentIndex(inventory, equipmentIndex) end
 
-    -- if we don't have an equipmentIndex, then we need to do it the old-fashioned way
     if charge ~= nil then charge = math.floor(charge) end
     if enchantmentCharge ~= nil then enchantmentCharge = math.floor(enchantmentCharge) end
 
@@ -110,19 +108,16 @@ function inventoryHelper.addItem(inventory, refId, count, charge, enchantmentCha
     end
 end
 
--- Sets a flag on an item in the inventory that indicates it is supposed to be in the player's equipment
--- table. This flag exists to map inventory items to their equivalent equipment table entries.
+-- Sets a flag on an item in the inventory to relate the inventory entry to an equipment entry.
 function inventoryHelper.setItemToEquipped(inventory, refId, count, charge, enchantmentCharge, equipIndex)
 
     -- If we're equipping an item, then it must exist in the inventory. If it does not exist in the inventory,
-    -- then we want to do nothing so as not to compromise the inventory. This case occurs with lockpicks and
-    -- probes reducing their charge (but not the last charge) because the inventory updates are handled elsewhere.
+    -- then we want to do nothing, because inventory handles lockpick and probe charges elsewhere.
     if inventoryHelper.containsItem(inventory, refId, charge, enchantmentCharge, nil) then
         local index = inventoryHelper.getItemIndex(inventory, refId, charge, enchantmentCharge, nil)
 
-        -- If there are multiple copies of the same exact item, we want to introduce a different, distinct copy of
-        -- this item that has the equipmentIndex value set. To that end, we will remove one count of the equipped
-        -- item from inventory and re-add it with equipmentIndex. Here we construct that copy, with equipmentIndex.
+        -- Equipped items must have a distinct inventory entry, even if there are other copies of the same thing in
+        -- the inventory. So, we remove one copy of the inventory entry and add it back with an equipmentIndex.
         local item = {}
         item.refId = inventory[index].refId
         item.count = count
@@ -139,10 +134,10 @@ function inventoryHelper.setItemToEquipped(inventory, refId, count, charge, ench
             inventory[index].count = inventory[index].count - count
         end
 
-        -- We always want to add equipped items to the front of the inventory, so that on server
-        -- start, they're always the first ones equipped. This is to address a bug where players on
-        -- connect are equipped with the first item in their inventory of a given refId instead of
-        -- being equipped with the item that most closely matches their current inventory.
+        -- Always  add equipped items to the front of the inventory. On server start, the stats
+        -- in the equipment table are ignored, and the stats given to equipment are always
+        -- whatever items show up first in order of inventory. This is probably a client-side bug,
+        -- but placing equipment first in the inventory compensates for it.
         table.insert(inventory, count, item)
     end
 end

--- a/scripts/player/base.lua
+++ b/scripts/player/base.lua
@@ -1020,39 +1020,8 @@ function BasePlayer:SaveEquipment()
             table.insert(newlyEquippedItems, newlyEquippedItem)
             table.insert(unequippedItems, self.data.equipment[index])
 
-        -- Special equip check case that can only be handled with help from eventHandler.lua: It is impossible
-        -- to detect here that a piece of equipment with an identical refId but a different charge was swapped
-        -- in-place (player equipped an iron longsword with full charge while they already had an identical
-        -- iron longsword except its charge is not full). With the information we have here, that case looks
-        -- identical to the case where a piece of equipment is simply being used and the charge decreases.
-        -- The solution used here is to record the fact that a piece of equipment just got activated by the
-        -- OnPlayerItemUse event, which conveniently gets activated when a piece of equipment is equipped.
-        elseif self.data.equipment[index].useTime ~= nil and self.data.equipment[index].useTime >= os.time() - 1 then
-
-            -- We make sure the client charge or enchantment is not equal to the server
-            local clientSideCharge = tes3mp.GetEquipmentItemCharge(self.pid, index)
-            local clientSideEnchantment = tes3mp.GetEquipmentItemEnchantmentCharge(self.pid, index)
-            if self.data.equipment[index].charge ~= clientSideCharge or self.data.equipment[index].enchantmentCharge ~= clientSideEnchantment then
-
-                -- Next, we make sure the client equipment matches a non-equipped server inventory item
-                local localNewEquipItemIndex = inventoryHelper.getItemIndex(self.data.inventory, itemRefId, clientSideCharge, clientSideEnchantment)
-                if localNewEquipItemIndex ~= nil then
-                    local newlyEquippedItem = {
-                        refId = itemRefId,
-                        count = tes3mp.GetEquipmentItemCount(self.pid, index),
-                        charge = tes3mp.GetEquipmentItemCharge(self.pid, index),
-                        enchantmentCharge = tes3mp.GetEquipmentItemEnchantmentCharge(self.pid, index),
-                        equipmentIndex = index
-                    }
-                    table.insert(newlyEquippedItems, newlyEquippedItem)
-                    table.insert(unequippedItems, self.data.equipment[index])
-                end
-            end
-        end
-
-        -- clear useTime so that it can't be mistakenly used again.
-        if self.data.equipment[index] ~= nil then
-            self.data.equipment[index].useTime = nil
+        -- There is another case, where a piece of equipment is swapped for the same equipment type but
+        -- with a different charge or enchantment charge. This case is handled 
         end
     end
 


### PR DESCRIPTION
There is no information that correlates exactly what entries in a player's equipment table relate to entries in that player's inventory table. This causes bugs where equipment's condition and enchantment changes frequently will not be written to that equipment's inventory entry, or that equipment's condition changes could get written to the wrong inventory entry.

The solution is to add a key to the inventory table called "equipmentIndex" for inventory items that are also in the equipment table. This will allow the server to write a piece of equipment's condition, charge, and quantity changes to the inventory when a piece of equipment is unequipped or when a player logs into the server.