### PR TITLE
Fix uniqueIndex returned from CreateObjectAtPlayer

### DIFF
--- a/scripts/logicHandler.lua
+++ b/scripts/logicHandler.lua
@@ -567,7 +567,7 @@ logicHandler.CreateObjectAtPlayer = function(pid, refId, packetType)
         rotX = tes3mp.GetRotX(pid), rotY = 0, rotZ = tes3mp.GetRotZ(pid)
     }
 
-    local objectUniqueIndex = logicHandler.CreateObjectAtLocation(cell, location, refId, packetType)[1]
+    local objectUniqueIndex = logicHandler.CreateObjectAtLocation(cell, location, refId, packetType)
     return objectUniqueIndex
 end
 


### PR DESCRIPTION
logicHandler.CreateObjectAtPlayer returns a nil objectUniqueIndex because it's trying to get the first index from the return value of logicHandler.CreateObjectAtLocation, which has already done this and is returning the single objectUniqueIndex