### PR TITLE
Customizable logicHandler.CreateObjects

### DIFF
--- a/scripts/commandHandler.lua
+++ b/scripts/commandHandler.lua
@@ -844,7 +844,7 @@ function commandHandler.ProcessCommand(pid, cmd)
                 packetType = "spawn"
             end
 
-            logicHandler.CreateObjectAtPlayer(targetPid, refId, packetType)
+            logicHandler.CreateObjectAtPlayer(targetPid, dataTableBuilder.BuildObjectData(refId), packetType)
         end
 
     elseif (cmd[1] == "anim" or cmd[1] == "a") and cmd[2] ~= nil then

--- a/scripts/dataTableBuilder.lua
+++ b/scripts/dataTableBuilder.lua
@@ -19,4 +19,17 @@ dataTableBuilder.BuildAIData = function(targetPid, targetUniqueIndex, action,
     return ai
 end
 
+-- Use with logicHandler.CreateObject* functions
+dataTableBuilder.BuildObjectData = function(refId, count, charge, enchantmentCharge, soul)
+
+	local objectData = {}
+	objectData.refId = refId
+	objectData.count = count or 1
+	objectData.charge = charge or -1
+	objectData.enchantmentCharge = enchantmentCharge or -1
+	objectData.soul = soul or ""
+
+	return objectData
+end
+
 return dataTableBuilder

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -1856,7 +1856,7 @@ eventHandler.OnObjectLoopTimeExpiration = function(loopIndex)
             if eventStatus.validDefaultHandler then
 
                 if loop.packetType == "place" or loop.packetType == "spawn" then
-                    logicHandler.CreateObjectAtPlayer(pid, loop.refId, loop.packetType)
+                    logicHandler.CreateObjectAtPlayer(pid, dataTableBuilder.BuildObjectData(loop.refId), loop.packetType)
                 elseif loop.packetType == "console" then
                     logicHandler.RunConsoleCommandOnPlayer(pid, loop.consoleCommand)
                 end

--- a/scripts/logicHandler.lua
+++ b/scripts/logicHandler.lua
@@ -447,6 +447,10 @@ logicHandler.CreateObjects = function(cellDescription, objectsToCreate, packetTy
     for _, object in pairs(objectsToCreate) do
 
         local refId = object.refId
+        local count = object.count
+        local charge = object.charge
+        local enchantmentCharge = object.enchantmentCharge
+        local soul = object.soul
         local location = object.location
 
         local mpNum = WorldInstance:GetCurrentMpNum() + 1
@@ -456,7 +460,7 @@ logicHandler.CreateObjects = function(cellDescription, objectsToCreate, packetTy
         -- Is this object based on a a generated record? If so, it needs special
         -- handling here and further below
         if logicHandler.IsGeneratedRecord(refId) then
-            
+
             local recordType = logicHandler.GetRecordTypeByRecordId(refId)
 
             if RecordStores[recordType] ~= nil then
@@ -505,8 +509,14 @@ logicHandler.CreateObjects = function(cellDescription, objectsToCreate, packetTy
                 tes3mp.SetObjectRefId(refId)
                 tes3mp.SetObjectRefNum(0)
                 tes3mp.SetObjectMpNum(mpNum)
-                tes3mp.SetObjectCharge(-1)
-                tes3mp.SetObjectEnchantmentCharge(-1)
+
+                if packetType == "place" then
+                    tes3mp.SetObjectCount(count)
+                    tes3mp.SetObjectCharge(charge)
+                    tes3mp.SetObjectEnchantmentCharge(enchantmentCharge)
+                    tes3mp.SetObjectSoul(soul)
+                end
+
                 tes3mp.SetObjectPosition(location.posX, location.posY, location.posZ)
                 tes3mp.SetObjectRotation(location.rotX, location.rotY, location.rotZ)
                 tes3mp.AddObject()
@@ -550,16 +560,25 @@ logicHandler.CreateObjects = function(cellDescription, objectsToCreate, packetTy
     return uniqueIndexes
 end
 
-logicHandler.CreateObjectAtLocation = function(cellDescription, location, refId, packetType)
+logicHandler.CreateObjectAtLocation = function(cellDescription, location, objectData, packetType)
 
     local objects = {}
-    table.insert(objects, { location = location, refId = refId, packetType = packetType })
+    table.insert(objects, {
+        location = location,
+        refId = objectData.refId,
+        count = objectData.count,
+        charge = objectData.charge,
+        enchantmentCharge = objectData.enchantmentCharge,
+        soul = objectData.soul,
+        packetType = packetType
+        }
+    )
 
     local objectUniqueIndex = logicHandler.CreateObjects(cellDescription, objects, packetType)[1]
     return objectUniqueIndex
 end
 
-logicHandler.CreateObjectAtPlayer = function(pid, refId, packetType)
+logicHandler.CreateObjectAtPlayer = function(pid, objectData, packetType)
 
     local cell = tes3mp.GetCell(pid)
     local location = {
@@ -567,7 +586,7 @@ logicHandler.CreateObjectAtPlayer = function(pid, refId, packetType)
         rotX = tes3mp.GetRotX(pid), rotY = 0, rotZ = tes3mp.GetRotZ(pid)
     }
 
-    local objectUniqueIndex = logicHandler.CreateObjectAtLocation(cell, location, refId, packetType)
+    local objectUniqueIndex = logicHandler.CreateObjectAtLocation(cell, location, objectData, packetType)
     return objectUniqueIndex
 end
 


### PR DESCRIPTION
_logicHandler.CreateObjectsAtPlayer_ and _logicHandler.CreateObjectAtLocation_ now both take _objectData_ table instead of _refId_ which allows for specifying multiple common properties.

_objectData_ can be built using added method _BuildObjectData(refId, count, charge, enchantmentCharge, soul)_ in _dataTableBuilder_.

This way any amount of an item e.g. _gold_ can be placed conveniently.

These extra properties (_count_, _charge_, _enchantmentCharge_ and _soul_) are not set if the _packetType_ is equal to _"spawn"_.

**Backwards compatibility:**
It's possible to replace _refId_ argument in both _logicHandler.CreateObjectAtPlayer_ and _logicHandler.CreateObjectAtLocation_ with _dataTableBuilder.BuildObjectData(refId)_