### PR TITLE
Made server use maxSpeedValue for speed.

### DIFF
--- a/scripts/player/base.lua
+++ b/scripts/player/base.lua
@@ -808,7 +808,7 @@ function BasePlayer:SaveAttributes(playerPacket)
         local attribute = playerPacket.attributes[attributeName]
         local maxAttributeValue = config.maxAttributeValue
 
-        if name == "Speed" then
+        if attributeName == "Speed" then
             maxAttributeValue = config.maxSpeedValue
         end
 


### PR DESCRIPTION
On my linux server, the regular maxAttributeValue was being used instead of the one for speed. This fixed the issue.