### PR TITLE
Categorize the two unknown variables

### DIFF
--- a/scripts/clientVariableScopes.lua
+++ b/scripts/clientVariableScopes.lua
@@ -44,7 +44,9 @@ if tableHelper.containsCaseInsensitiveString(clientDataFiles, "Morrowind.esm") t
                 "expredoran", "expmagesguild", "expfightersguild", "exptemple", "expmoragtong", "expimperialcult",
                 "expimperiallegion", "expthievesguild",
                 -- quest variables that are already set correctly without being synced
-                "fargothwalk"
+                "fargothwalk",
+                -- not actually used at all
+                "abelmawiacounter"
             },
             personal = {
                 -- player state
@@ -69,7 +71,7 @@ if tableHelper.containsCaseInsensitiveString(clientDataFiles, "Morrowind.esm") t
                 -- side quests for rescues
                 "freedslavescounter", "madurarescued",
                 -- other side quests
-                "threadswebspinner", "monopolyvotes", "bone"
+                "threadswebspinner", "monopolyvotes", "bone", "ownershiphhcs"
             },
             kills = {
                 -- main quest
@@ -89,7 +91,6 @@ if tableHelper.containsCaseInsensitiveString(clientDataFiles, "Morrowind.esm") t
                 "duelactive"
             },
             unknown = {
-                "ownershiphhcs", "abelmawiacounter"
             }
         }
     }


### PR DESCRIPTION
using TES3CMD to do a through search for abelmawiacounter and OwnershipHHCs.

OwnershipHHCs is used by https://en.uesp.net/wiki/Morrowind:The_Caldera_Spy
It allows you to loot the chest(and her house) once you convince her.

It only found the declaration in morrowind.esm and tribunal.esm of abelmawiacounter.

[here is the output of the search, it searched for both variables.](https://github.com/TES3MP/CoreScripts/files/8319700/Morrowind.esm-dump.log)
