### PR TITLE
Add SHotN variables to clientVariableScopes

### DIFF
--- a/scripts/clientVariableScopes.lua
+++ b/scripts/clientVariableScopes.lua
@@ -379,11 +379,11 @@ end
 
 if tableHelper.containsCaseInsensitiveString(clientDataFiles, "Sky_Main.esm") then
 
-	local addedVariableScopes = {
+    local addedVariableScopes = {
         globals = {
             ignored = {
                 -- game state
-				"Sky_qRe_KG1_global", "Sky_TempVar_glb"
+                "Sky_qRe_KG1_global", "Sky_TempVar_glb"
                 -- quest variables that are already set correctly without being synced
                 "Sky_qRe_DSW04_BreadCounter_glb",
                 -- not actually used at all
@@ -441,8 +441,8 @@ if tableHelper.containsCaseInsensitiveString(clientDataFiles, "Sky_Main.esm") th
             },
             worldwide = {
                 -- mechanisms
-				"Sky_iRe_KW_RPVault_glb", "Sky_qRe_KW_MG06_PenumbraState", "Sky_qRe_KWTG06_Button_glb",
-				-- objects
+                "Sky_iRe_KW_RPVault_glb", "Sky_qRe_KW_MG06_PenumbraState", "Sky_qRe_KWTG06_Button_glb",
+                -- objects
                 "Sky_qRe_DSW01_LetterState_glb",
                 -- npc behavior
                 "Sky_qRe_HA1_CultistState_glb", "Sky_qRe_HA3_Sick_glb", "Sky_qRe_KW_MG04_Returned_glb",

--- a/scripts/clientVariableScopes.lua
+++ b/scripts/clientVariableScopes.lua
@@ -377,5 +377,85 @@ if tableHelper.containsCaseInsensitiveString(clientDataFiles, "Cyrodiil_Main.esm
     tableHelper.merge(clientVariableScopes, addedVariableScopes, true)
 end
 
+if tableHelper.containsCaseInsensitiveString(clientDataFiles, "Sky_Main.esm") then
+
+	local addedVariableScopes = {
+        globals = {
+            ignored = {
+                -- game state
+				"Sky_qRe_KG1_global", "Sky_TempVar_glb"
+                -- quest variables that are already set correctly without being synced
+                "Sky_qRe_DSW04_BreadCounter_glb",
+                -- not actually used at all
+                "Sky_iRe_DH99_Wine_glb", "sky_qRe_KG4_AmbCount", "sky_qRe_KG4_Day",
+                "sky_qRe_KG4_Day2"
+            },
+            personal = {
+                -- player state
+                "Sky_qRe_KG4_Transformed_glb",
+                -- tavern rents
+                "Sky_Rent_DSE_Shadowkey", "Sky_Rent_DSW_DragonFountain", "Sky_Rent_DSW_NukraTikil", 
+                "Sky_Rent_HA_Jhorcian", "Sky_Rent_KW_Dancing_Saber", "Sky_Rent_KW_Ruby_Drake",
+                "Sky_Rent_LH_Daracam", "Sky_Rent_MER_Rhuma", "Sky_Rent_VF_EvenOddsInn",
+                -- mercenary contracts
+                "Sky_Merc_Rismund_DaysLeft",
+                -- miscellaneous variables related to player-specific actions
+                "Sky_qRe_BM04_Door_glb", "Sky_qRe_KW01_Book1_glb", "Sky_qRe_KW01_Book2_glb", 
+                "Sky_qRe_KW01_Book3_glb", "Sky_qRe_KW01_Book4_glb"
+            },
+            quest = {
+
+                -- other side quests
+                "Sky_qRe-Vornd1_GLOBAL1", "Sky_qRe-Vornd1_GLOBAL2", "Sky_qRe_DSE01_Donation_glb", 
+                "Sky_qRe_DSTG03_Informants_glb", "Sky_qRe_DSTG07_MoveCael_glb", "Sky_qRe_DSW01_CacheFound_glb",
+                "Sky_qRe_DSW01_Dagger_glb", "Sky_qRe_DSW01_Scimitar_glb", "Sky_qRe_DSW01_Saber_glb", 
+                "Sky_qRe_DSW02_Auth_glb", "Sky_qRe_KG5_SViir_glb", "Sky_qRe_KWFG04_Owner_glb", 
+                "Sky_qRE_KWTG07_Glb_QuestDone", "Sky_qRe_MAI04_Counter_glb", "Sky_qRe_NAR01_Investigate_glb"
+                
+            },
+            kills = {
+                -- main quest
+                "Sky_qRe_DSMQ_AlaktolDead", "Sky_qRe_DSMQ_JonaDead",
+                -- side quests
+                "Sky_qRe_Ald1_global", "Sky_qRe_DS_B01_AlreadyDead_glb", "Sky_qRe_DS_B02_AlreadyDead_glb", 
+                "Sky_qRe_DS_B05_Counter_glb", "Sky_qRe_DSW01_MesaraDead_glb", "Sky_qRe_BM_FhegainDead_glb",
+                "Sky_qRe_HA1_glb_KillCheck", "Sky_qRe_HA1_RilorDead_glb", "Sky_qRe_KG2_Counter_glb",
+                "Sky_qRe_KG4_Counter", "Sky_qRe_KW_B01_glb_Counter", "Sky_qRe_KW_B02_AlreadyDead",
+                "Sky_qRe_KW_B04_glb_Counter", "Sky_qRe_KW_B06_glb_Counter", "Sky_qRe_KW_B08_glb_Counter",
+                "Sky_qRe_KW_B09_glb_Counter", "Sky_qRe_KW_B10_AlreadyDead", "Sky_qRe_KW_B10_glb_Counter",
+                "Sky_qRe_KW_MG06_GhostsKilled", "sky_qRe_KWFG02_Counter", "sky_qRe_KWFG03_Counter",
+                "Sky_qRe_MAI03_Counter_glb", "Sky_qRe_MAI04_Dead_glb", "Sky_qRE_VF3_Killed_glb",
+                -- arena kill counts
+                "Sky_qRe_DSE04_Count02_glb", "Sky_qRe_DSE04_Count03_glb", "Sky_qRe_DSE04_Count05_glb", 
+                "Sky_qRe_DSE04_Count07_glb"
+            },
+            factionRanks = {
+                -- faction reputation
+                "Sky_qRe_DSMG_Rep_Glb", "Sky_Rep_FireHand_glb",
+                -- membership in mini-factions
+                "Sky_qRe_DSE04_Owner_glb"
+            },
+            factionExpulsion = {
+                -- faction expulsion forgiveness and timers
+                "Sky_Glb_ExpFightersGuild", "Sky_qRe_KWTG_Expelled_glb"
+            },
+            worldwide = {
+                -- mechanisms
+				"Sky_iRe_KW_RPVault_glb", "Sky_qRe_KW_MG06_PenumbraState", "Sky_qRe_KWTG06_Button_glb",
+				-- objects
+                "Sky_qRe_DSW01_LetterState_glb",
+                -- npc behavior
+                "Sky_qRe_HA1_CultistState_glb", "Sky_qRe_HA3_Sick_glb", "Sky_qRe_KW_MG04_Returned_glb",
+                -- arena State
+                "Sky_qRe_DSE_ArenaFight_glb"
+            },
+            unknown = {
+                
+            }
+        }
+    }
+
+    tableHelper.merge(clientVariableScopes, addedVariableScopes, true)
+end
 
 return clientVariableScopes


### PR DESCRIPTION
Adds the variables from SHotN. This was a bit tricky deciding how they are used. SHotN passes variables around more then I remember TR doing but it is a different team with differing styles.

Here is the log of my variable dump it is a zip since GITHub didn't want to attach the log since it might be too big.
[Sky_Main.esm-dump.zip](https://github.com/TES3MP/CoreScripts/files/8477521/Sky_Main.esm-dump.zip)


