### PR TITLE
Ensure substrings in StoreRecord's inputConcatenation get actually comma delimited

### DIFF
--- a/scripts/commandHandler.lua
+++ b/scripts/commandHandler.lua
@@ -1079,7 +1079,7 @@ function commandHandler.StoreRecord(pid, cmd)
                 Players[pid]:Message("Please provide the minimum number of arguments required.\n")
                 return
             else
-                inputConcatenation = tableHelper.concatenateFromIndex(cmd, 5)
+                inputConcatenation = tableHelper.concatenateFromIndex(cmd, 5, ",")
                 inputValues = tableHelper.getTableFromCommaSplit(inputConcatenation)
             end
 


### PR DESCRIPTION
When creating a custom NPC via /storerecord command, it's not possible to add an item to their inventory of count greater than 1 (regardless of the number entered in the chat command it always defaults to 1). 

1082: _inputConcatenation_ = tableHelper.concatenateFromIndex(cmd, 5) -- no delimiter specified, therefore concatenated substrings are single space delimited
1083: _inputValues_ = tableHelper.getTableFromCommaSplit(inputConcatenation) -- expects comma delimited substrings, whereas these are actually single space delimited

1134: local _inputItemId_ = inputValues[1] -- contains both id and the amount at this point
1135: local _inputItemCount_ = tonumber(inputValues[2]) -- is nil, therefore always defaults to 1, regardless the amount specified in chat command being a number