### PR TITLE
Prevent crash when attepting to reload an invalid module

### DIFF
--- a/scripts/commandHandler.lua
+++ b/scripts/commandHandler.lua
@@ -689,6 +689,12 @@ function commandHandler.ProcessCommand(pid, cmd)
             local wasLoaded = false
 
             if package.loaded[scriptName] then
+                
+                if type(package.loaded[scriptName]) ~= "table" then
+					Players[pid]:Message(scriptName .. " was already loaded but it is not a valid lua module and thus cannot be properly reloaded.\n")
+					return
+				end
+                
                 Players[pid]:Message(scriptName .. " was already loaded, so it is being reloaded.\n")
                 wasLoaded = true
             end

--- a/scripts/commandHandler.lua
+++ b/scripts/commandHandler.lua
@@ -691,9 +691,9 @@ function commandHandler.ProcessCommand(pid, cmd)
             if package.loaded[scriptName] then
                 
                 if type(package.loaded[scriptName]) ~= "table" then
-					Players[pid]:Message(scriptName .. " was already loaded but it is not a valid lua module and thus cannot be properly reloaded.\n")
-					return
-				end
+		    Players[pid]:Message(scriptName .. " was already loaded but it is not a valid lua module and thus cannot be properly reloaded.\n")
+		    return
+		end
                 
                 Players[pid]:Message(scriptName .. " was already loaded, so it is being reloaded.\n")
                 wasLoaded = true


### PR DESCRIPTION
720: for key, value in pairs(package.loaded[scriptName]) do

- package.loaded[scriptName] is expected to be a table, not all lua scripts return one
- if lua script does not provide a return value, require implicitly returns true to package.loaded[scriptName] instead, this results in an attempt to iterate over boolean value

reference: https://www.lua.org/manual/5.1/manual.html#:~:text=Once%20a%20loader%20is%20found,of%20package.loaded%5Bmodname%5D.