### PR TITLE
Update player/base.lua

### DIFF
--- a/scripts/player/base.lua
+++ b/scripts/player/base.lua
@@ -331,7 +331,7 @@ function BasePlayer:EndCharGen()
     self:SaveClass(packetReader.GetPlayerPacketTables(self.pid, "PlayerClass"))
     self:SaveStatsDynamic(packetReader.GetPlayerPacketTables(self.pid, "PlayerStatsDynamic"))
     self:SaveEquipment(packetReader.GetPlayerPacketTables(self.pid, "PlayerEquipment"))
-	self:SaveShapeshift(packetReader.GetPlayerPacketTables(self.pid, "PlayerShapeshift"))
+    self:SaveShapeshift(packetReader.GetPlayerPacketTables(self.pid, "PlayerShapeshift"))
     self:SaveIpAddress()
     self:CreateAccount()
 

--- a/scripts/player/base.lua
+++ b/scripts/player/base.lua
@@ -331,6 +331,7 @@ function BasePlayer:EndCharGen()
     self:SaveClass(packetReader.GetPlayerPacketTables(self.pid, "PlayerClass"))
     self:SaveStatsDynamic(packetReader.GetPlayerPacketTables(self.pid, "PlayerStatsDynamic"))
     self:SaveEquipment(packetReader.GetPlayerPacketTables(self.pid, "PlayerEquipment"))
+	self:SaveShapeshift(packetReader.GetPlayerPacketTables(self.pid, "PlayerShapeshift"))
     self:SaveIpAddress()
     self:CreateAccount()
 


### PR DESCRIPTION
added saving of Shapeshift following the creation of a character in EndChargGen in order to avoid a server crash when using linked data in custom scripts